### PR TITLE
Gitignore update for Bower & Gulp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+# Node & Bower gitignore
 node_modules/*
 npm-debug.log
+src/vendor/
+
+# gulp destination file ignore
+dist/
 
 #Map Crap
 


### PR DESCRIPTION
Pour avoir un travail sur .git le plus propre possible, l'idée est d'ignorer les fichiers générés et les dépendances.
De toute façon, dans notre workflow on s'impose un `gulp doallthethings`, un `npm update` et un `bower update` après un `git pull`.
Cela permettra d'éviter les conflits liés aux fichiers minifiés quand on bosse à plusieurs sur un même projet :)